### PR TITLE
fixed ANC subsequent visit error 

### DIFF
--- a/ui/app/common/concept-set/directives/conceptSet.js
+++ b/ui/app/common/concept-set/directives/conceptSet.js
@@ -772,11 +772,14 @@ angular.module('bahmni.common.conceptSet')
                                     obs.groupMembers.forEach(member =>{
                                         if(member.label == 'LOR'){    
 
-                                           var today = new Date();
-                                           var lastMenstrualDate = new Date(edd)
-                                           var gestationalAge = Math.floor((today - lastMenstrualDate) / (7 * 24 * 60 * 60 * 1000))
-                                           member.groupMembers[0].groupMembers[6].value = gestationalAge
-                                           
+                                            if(edd == null){
+                                                console.log("Do not need LMP since its a subsequent visit")
+                                            }else{
+                                                var today = new Date();
+                                                var lastMenstrualDate = new Date(edd);
+                                                var gestationalAge = Math.floor((today - lastMenstrualDate) / (7 * 24 * 60 * 60 * 1000));
+                                                member.groupMembers[0].groupMembers[6].value = gestationalAge;
+                                            }
                                         }
                                     })
                             });


### PR DESCRIPTION
Subsequent visit for ANC could not save patient 

SOLUTION:
- Added a conditional statement that checks if LMP is empty or not.